### PR TITLE
Fix typo in API documentation introduction pages

### DIFF
--- a/source/includes/wp-api-v1/_introduction.md
+++ b/source/includes/wp-api-v1/_introduction.md
@@ -10,7 +10,7 @@ The following table shows API versions present in each major version of WooComme
 |-------------|------------|------------|
 | `v1`        | 2.6.x or later | 4.4 or later |
 
-Prior to 2.6, WooCommerce had it's own REST API separate from WordPress which is now known as the legacy API. You can find the documentation for the legacy API separately.
+Prior to 2.6, WooCommerce had its own REST API separate from WordPress which is now known as the legacy API. You can find the documentation for the legacy API separately.
 
 | API Version | WC Version | WP Version | Documentation |
 |-------------|------------|------------|---------------|

--- a/source/includes/wp-api-v2/_introduction.md
+++ b/source/includes/wp-api-v2/_introduction.md
@@ -11,7 +11,7 @@ The following table shows API versions present in each major version of WooComme
 | `v2`        | 3.0.x or later | 4.4 or later | -                         |
 | `v1`        | 2.6.x or later | 4.4 or later | [v1 docs](wp-api-v1.html) |
 
-Prior to 2.6, WooCommerce had it's own REST API separate from WordPress which is now known as the legacy API. You can find the documentation for the legacy API separately.
+Prior to 2.6, WooCommerce had its own REST API separate from WordPress which is now known as the legacy API. You can find the documentation for the legacy API separately.
 
 | API Version | WC Version | WP Version | Documentation |
 |-------------|------------|------------|---------------|


### PR DESCRIPTION
This fixes a small typo that was pointed out via a ticket.