### PR TITLE
Fix documentation on ruby client set up

### DIFF
--- a/source/includes/wp-api-v2/_introduction.md
+++ b/source/includes/wp-api-v2/_introduction.md
@@ -234,12 +234,12 @@ wcapi = API(
 require "woocommerce_api"
 
 woocommerce = WooCommerce::API.new(
-  "http://example.com", # Your store URL
+  "https://example.com", # Your store URL
   "consumer_key", # Your consumer key
   "consumer_secret", # Your consumer secret
   {
-    wp_json: true, # Enable the WP REST API integration
-    version: "v3" # WooCommerce WP REST API version
+    wp_api: true, # Enable the WP REST API integration
+    version: "wc/v2" # WooCommerce WP REST API version
   }
 )
 ```


### PR DESCRIPTION
The set up documentation for the ruby client did not match the current gem.
I altered the documentation to match what the gem reccomends which can be
found in the README.md at https://github.com/woocommerce/wc-api-ruby#setup