### PR TITLE
Fixes PHP example

### DIFF
--- a/source/includes/v2/_reports.md
+++ b/source/includes/v2/_reports.md
@@ -41,7 +41,7 @@ print(wcapi.get("reports").json())
 ```
 
 ```php
-<?php print_r($woocommerce->reports->get()); ?>
+<?php print_r($woocommerce->get('reports')); ?>
 ```
 
 ```ruby


### PR DESCRIPTION
As shown on [documentation](http://woocommerce.github.io/woocommerce-rest-api-docs/#reports) that's the correct way to list all reports.