### PR TITLE
Fix Documentation for Shipping Lines Total

### DIFF
--- a/source/includes/v2/_orders.md
+++ b/source/includes/v2/_orders.md
@@ -177,7 +177,7 @@ curl -X POST https://example.com/wc-api/v2/orders \
       {
         "method_id": "flat_rate",
         "method_title": "Flat Rate",
-        "total": 10
+        "total": "10.00"
       }
     ]
   }
@@ -232,7 +232,7 @@ var data = {
       {
         method_id: 'flat_rate',
         method_title: 'Flat Rate',
-        total: 10
+        total: '10.00'
       }
     ]
   }
@@ -291,7 +291,7 @@ data = {
             {
                 "method_id": "flat_rate",
                 "method_title": "Flat Rate",
-                "total": 10
+                "total": "10.00"
             }
         ]
     }
@@ -349,7 +349,7 @@ $data = array(
             array(
                 'method_id' => 'flat_rate',
                 'method_title' => 'Flat Rate',
-                'total' => 10
+                'total' => '10.00'
             )
         )
     )
@@ -407,7 +407,7 @@ data = {
         {
           method_id: "flat_rate",
           method_title: "Flat Rate",
-          total: 10
+          total: "10.00"
         }
     ]
   }


### PR DESCRIPTION
The documentation has `total` as an integer however this throws an invalid parameter exception 
`Error: Invalid parameter(s): shipping_lines [rest_invalid_param]`

This parameter should be a string. Docs have been updated for accuracy.