### PR TITLE
Removed deprecated warning on v3 docs

### DIFF
--- a/source/v3.html.md
+++ b/source/v3.html.md
@@ -37,6 +37,4 @@ includes:
   - v3/authentication-endpoint
 
 search: false
-
-warning: <i class="info"></i> This documentation is for the WooCommerce API v3 API which is now deprecated. <a href="http://woocommerce.github.io/woocommerce-rest-api-docs/">Please use the latest REST API version</a>.
 ---


### PR DESCRIPTION
I think this a simple error with the docs since v3 is the latest version so it shouldn't show a deprecation warning.