### PR TITLE
Update broken link to Requestbin

### DIFF
--- a/source/includes/wp-api-v3/_introduction.md
+++ b/source/includes/wp-api-v3/_introduction.md
@@ -267,7 +267,7 @@ Some useful tools you can use to access the API include:
 - [Paw HTTP Client](https://itunes.apple.com/us/app/paw-http-client/id584653203?mt=12) - Another HTTP client for Mac OS X.
 - [RESTClient, a debugger for RESTful web services](https://addons.mozilla.org/en-US/firefox/addon/restclient/) - Free Firefox add-on.
 - [Advanced REST client](https://chrome.google.com/webstore/detail/advanced-rest-client/hgmloofddffdnphfgcellkdfbfbjeloo) - Free Google Chrome extension.
-- [RequestBin](https://requestb.in) - Allows you test webhooks.
+- [RequestBin](https://requestbin.com) - Allows you test webhooks.
 - [Hookbin](https://hookbin.com/) - Another tool to test webhooks.
 
 ## Learn more ##


### PR DESCRIPTION
Requestb.in was discontinued and the link is now broken (see https://github.com/Runscope/requestbin). We recently launched an updated, hosted version of the tool at RequestBin.com with new features including private bins with Google / Github authentication, ability to pause/filter the event stream and an improved UI.